### PR TITLE
Add support for alternative I2C Busses

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -54,10 +54,19 @@ QMC5883LCompass compass;
 Then in the setup() function add:
 ```
 void setup(){
-  compass.init();
+  compass.init(); //I2CBus: Takes an I2CBus which was previously defined. Defaults to the "Wire" Library
 }
 ```
+to connect the sensor through the default I2C Interface.
 
+If you want to connect the Sensor through a previously defined Interface, for example a TwoWire interface, add:
+```
+void setup(){
+  TwoWire bus = TwoWire(0);
+  bus.begin(sda_pin, scl_pin, speed); //Initialize the bus with i2c pins and speed (neccesary for ESP8266 and ESP32),
+  compass.init(&bus); //&bus: assign the bus to the sensor.
+}
+```
 
 ### Getting Values
 

--- a/readme.md
+++ b/readme.md
@@ -54,7 +54,7 @@ QMC5883LCompass compass;
 Then in the setup() function add:
 ```
 void setup(){
-  compass.init(); //I2CBus: Takes an I2CBus which was previously defined. Defaults to the "Wire" Library
+  compass.init();
 }
 ```
 to connect the sensor through the default I2C Interface.

--- a/readme.md
+++ b/readme.md
@@ -62,8 +62,8 @@ to connect the sensor through the default I2C Interface.
 If you want to connect the Sensor through a previously defined Interface, for example a TwoWire interface, add:
 ```
 void setup(){
-  TwoWire bus = TwoWire(0);
-  bus.begin(sda_pin, scl_pin, speed); //Initialize the bus with i2c pins and speed (neccesary for ESP8266 and ESP32),
+  TwoWire bus = TwoWire(0); //Initialize a TwoWire-Bus called "bus" and assign it to bus 0.
+  bus.begin(sda_pin, scl_pin, speed); //Initialize the bus with i2c pins and speed (neccesary for ESP8266 and ESP32).
   compass.init(&bus); //&bus: assign the bus to the sensor.
 }
 ```

--- a/src/QMC5883LCompass.cpp
+++ b/src/QMC5883LCompass.cpp
@@ -1,8 +1,8 @@
 /*
 ===============================================================================================================
-QMC5883LCompass.h
+QMC5883L.h
 Library for using QMC5583L series chip boards as a compass.
-Learn more at [https://github.com/mprograms/QMC5883LCompass]
+Learn more at [https://github.com/mprograms/QMC5883L]
 
 Supports:
 
@@ -57,6 +57,7 @@ OVER SAMPLE RATIO (OSR)
 #include <Wire.h>
 
 QMC5883LCompass::QMC5883LCompass() {
+
 }
 
 
@@ -66,8 +67,9 @@ QMC5883LCompass::QMC5883LCompass() {
 	
 	@since v0.1;
 **/
-void QMC5883LCompass::init(){
-	Wire.begin();
+void QMC5883LCompass::init(TwoWire *bus){
+	_int_bus = bus;
+	_int_bus->begin();
 	_writeReg(0x0B,0x01);
 	setMode(0x01,0x0C,0x10,0X00);
 }
@@ -95,10 +97,10 @@ void QMC5883LCompass::setADDR(byte b){
 **/
 // Write register values to chip
 void QMC5883LCompass::_writeReg(byte r, byte v){
-	Wire.beginTransmission(_ADDR);
-	Wire.write(r);
-	Wire.write(v);
-	Wire.endTransmission();
+	_int_bus->beginTransmission(_ADDR);
+	_int_bus->write(r);
+	_int_bus->write(v);
+	_int_bus->endTransmission();
 }
 
 
@@ -160,14 +162,14 @@ void QMC5883LCompass::setCalibration(int x_min, int x_max, int y_min, int y_max,
 	@since v0.1;
 **/
 void QMC5883LCompass::read(){
-	Wire.beginTransmission(_ADDR);
-	Wire.write(0x00);
-	int err = Wire.endTransmission();
+	_int_bus->beginTransmission(_ADDR);
+	_int_bus->write(0x00);
+	int err = _int_bus->endTransmission();
 	if (!err) {
-		Wire.requestFrom(_ADDR, (byte)6);
-		_vRaw[0] = (int)(int16_t)(Wire.read() | Wire.read() << 8);
-		_vRaw[1] = (int)(int16_t)(Wire.read() | Wire.read() << 8);
-		_vRaw[2] = (int)(int16_t)(Wire.read() | Wire.read() << 8);
+		_int_bus->requestFrom(_ADDR, (byte)6);
+		_vRaw[0] = (int)(int16_t)(_int_bus->read() | _int_bus->read() << 8);
+		_vRaw[1] = (int)(int16_t)(_int_bus->read() | _int_bus->read() << 8);
+		_vRaw[2] = (int)(int16_t)(_int_bus->read() | _int_bus->read() << 8);
 
 		if ( _calibrationUse ) {
 			_applyCalibration();

--- a/src/QMC5883LCompass.cpp
+++ b/src/QMC5883LCompass.cpp
@@ -64,7 +64,11 @@ QMC5883LCompass::QMC5883LCompass() {
 /**
 	INIT
 	Initialize Chip - This needs to be called in the sketch setup() function.
-	
+
+	Optional:
+	A predefined TwoWire bus can be assigned using "init(&YourPredefinedBus);": 
+	Example: 
+		compass.init(&I2C_1);
 	@since v0.1;
 **/
 void QMC5883LCompass::init(TwoWire *bus){

--- a/src/QMC5883LCompass.cpp
+++ b/src/QMC5883LCompass.cpp
@@ -2,7 +2,7 @@
 ===============================================================================================================
 QMC5883LCompass.h
 Library for using QMC5583L series chip boards as a compass.
-Learn more at [https://github.com/mprograms/QMC5883L]
+Learn more at [https://github.com/mprograms/QMC5883LCompass]
 
 Supports:
 

--- a/src/QMC5883LCompass.cpp
+++ b/src/QMC5883LCompass.cpp
@@ -1,6 +1,6 @@
 /*
 ===============================================================================================================
-QMC5883L.h
+QMC5883LCompass.h
 Library for using QMC5583L series chip boards as a compass.
 Learn more at [https://github.com/mprograms/QMC5883L]
 

--- a/src/QMC5883LCompass.h
+++ b/src/QMC5883LCompass.h
@@ -1,6 +1,5 @@
 #ifndef QMC5883L_Compass
 #define QMC5883L_Compass
-
 #include "Arduino.h"
 #include "Wire.h"
 
@@ -9,7 +8,7 @@ class QMC5883LCompass{
 	
   public:
     QMC5883LCompass();
-	void init();
+	void init(TwoWire *bus = &Wire);
     void setADDR(byte b);
     void setMode(byte mode, byte odr, byte rng, byte osr);
 	void setSmoothing(byte steps, bool adv);
@@ -24,6 +23,7 @@ class QMC5883LCompass{
 	void getDirection(char* myArray, int azimuth);
 	
   private:
+	TwoWire *_int_bus;
     void _writeReg(byte reg,byte val);
 	int _get(int index);
 	bool _smoothUse = false;


### PR DESCRIPTION
I added functionality for a predefined I2C (TwoWire) Bus. This is neccesary for ESP8266 and ESP32.
It defaults to the "Wire" Library so its backwards compatible.

Tested on ESP32-C3 and Arduino Uno