### PR TITLE
Fix calibration.ino

### DIFF
--- a/examples/calibration/calibration.ino
+++ b/examples/calibration/calibration.ino
@@ -40,7 +40,7 @@ Release under the GNU General Public License v3
 
 QMC5883LCompass compass;
 
-int calibrationData[3][2];
+int calibrationData[3][2] = {{65000, -65000}, {65000, -65000}, {65000, -65000}};
 bool changed = false;
 bool done = false;
 int t = 0;


### PR DESCRIPTION
After stock calibration i get result like:
compass.setCalibration(0, 1543, -6345, 0, -4900, 0); and it doesn't work!
After this fix, calibration is:
compass.setCalibration(316, 1543, -6345, -4717, -4900, -4647); and it work well.