### PR TITLE
Fix Calibration bug

### DIFF
--- a/src/QMC5883LCompass.cpp
+++ b/src/QMC5883LCompass.cpp
@@ -150,6 +150,7 @@ void QMC5883LCompass::setSmoothing(byte steps, bool adv){
 void QMC5883LCompass::calibrate() {
 	clearCalibration();
 	long calibrationData[3][2] = {{65000, -65000}, {65000, -65000}, {65000, -65000}};
+	read();
   	long	x = calibrationData[0][0] = calibrationData[0][1] = getX();
   	long	y = calibrationData[1][0] = calibrationData[1][1] = getY();
   	long	z = calibrationData[2][0] = calibrationData[2][1] = getZ();


### PR DESCRIPTION
Fixed a bug that the initial value of calibrationData might become an abnormal value when the calibrate function is called. It is necessary to execute the read function before calling getX, getY, getZ function in the function concerned.