### PR TITLE
Fix calibration initialization issue in calibrate()

### DIFF
--- a/src/QMC5883LCompass.cpp
+++ b/src/QMC5883LCompass.cpp
@@ -150,9 +150,7 @@ void QMC5883LCompass::setSmoothing(byte steps, bool adv){
 void QMC5883LCompass::calibrate() {
 	clearCalibration();
 	long calibrationData[3][2] = {{65000, -65000}, {65000, -65000}, {65000, -65000}};
-  	long	x = calibrationData[0][0] = calibrationData[0][1] = getX();
-  	long	y = calibrationData[1][0] = calibrationData[1][1] = getY();
-  	long	z = calibrationData[2][0] = calibrationData[2][1] = getZ();
+  	long x, y, z;
 
 	unsigned long startTime = millis();
 


### PR DESCRIPTION
Previously, calibrationData[3][2] was set to zeros since read() was not called before getX(), getY(), and getZ(). This caused incorrect calibration when any axis had consistently positive or negative values, resulting in max/min values being zero.

This fix removes the unnecessary assignment to calibrationData[3][2], ensuring proper calibration.